### PR TITLE
 (feat): add built-in option to clone the canvas (w/ support for alternate canvas implementations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <br>
 [![NPM](https://nodei.co/npm/trim-canvas.png?downloads=true&downloadRank=true&stars=true)](https://npmjs.org/package/trim-canvas)
 
-A tiny (< 100 LoC) library for trimming whitespace from a `canvas` element with no dependencies.
+A tiny (~100 LoC) library for trimming whitespace from a `canvas` element with no dependencies.
 
 ## Installation
 
@@ -35,8 +35,28 @@ trimCanvas(canvas)
 ```
 
 If you don't want to mess with your existing canvas, then simply clone the canvas element beforehand.
+`trim-canvas` v0.2+ has built-in support for cloning:
+
+```javascript
+const newTrimmedCanvas = trimCanvas(canvas, {clone: true})
+```
+
+Can view the [full list of options](#API) below.
 
 `trim-canvas` returns the canvas element for easy chaining.
+
+### API
+
+#### `trimCanvas(canvas, options)`
+
+- arguments
+  - **canvas** *Canvas object* The canvas to be trimmed.
+  - **options** *object* Optional arguments.
+    - **clone** *bool* Whether to clone the canvas before trimming (default: `false`).
+    - **createCanvas** *function* A custom function to create a Canvas (defaults to DOM implementation).
+      Supports [`node-canvas`'s `createCanvas`](https://github.com/Automattic/node-canvas#createcanvas).
+
+- returns the trimmed canvas (original or cloned)
 
 ## Example
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trim-canvas",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A tiny library for trimming whitespace from a canvas element",
   "main": "build/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-export default function trimCanvas (canvas) {
+export default function trimCanvas (canvas, options = {}) {
+  const {clone} = options
   const context = canvas.getContext('2d')
 
   const imgWidth = canvas.width
@@ -20,6 +21,15 @@ export default function trimCanvas (canvas) {
   // get the relevant data from the calculated coordinates
   const trimmedData = context.getImageData(cropLeft, cropTop, cropXDiff,
     cropYDiff)
+
+  // early return if cloning
+  if (clone) {
+    const copy = document.createElement('canvas')
+    copy.width = cropXDiff
+    copy.height = cropYDiff
+    copy.getContext('2d').putImageData(trimmedData, 0, 0)
+    return copy
+  }
 
   // set the trimmed width and height
   canvas.width = cropXDiff

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 export default function trimCanvas (canvas, options = {}) {
   const {clone} = options
+  let {createCanvas = createCanvasDOM} = options // support node-canvas, etc
+
   const context = canvas.getContext('2d')
 
   const imgWidth = canvas.width
@@ -24,7 +26,7 @@ export default function trimCanvas (canvas, options = {}) {
 
   // early return if cloning
   if (clone) {
-    const copy = document.createElement('canvas')
+    const copy = createCanvas()
     copy.width = cropXDiff
     copy.height = cropYDiff
     copy.getContext('2d').putImageData(trimmedData, 0, 0)
@@ -94,4 +96,8 @@ function scanX (fromLeft, imgWidth, imgHeight, imgData) {
 
   // the whole image is white already
   return null
+}
+
+function createCanvasDOM () {
+  return document.createElement('canvas')
 }


### PR DESCRIPTION
- ~(refactor): use const everywhere instead of let  …~
- (feat): add built-in option to clone the canvas  …
- (feat): add support for alternate canvas implementations  …
- (docs): add API and Usage docs for new optional arguments  …
- (pub): publish v0.2.0

Fixes #6 

Looking to add at least one test in before merging.
Not sure if I should use `ava` + `window` or `cypress` or `node-canvas`.
I think the ideal test would be to have a fixture of trimmed `ImageData` (instantiated probably like [this MDN example](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/createImageData#Examples)), insert into a new, larger Canvas, and then trim it and check the trimmed ImageData against the fixture. If it's small enough, hopefully won't take that much code to create an equals check.
An alternative, indirect (but simpler) test would be to check that the width and height decreased to the preset/known amount.